### PR TITLE
[Bugfix] Order values when extracting from DB - revamped

### DIFF
--- a/altiProfil/lib/AltiServicesFromDB.php
+++ b/altiProfil/lib/AltiServicesFromDB.php
@@ -107,7 +107,7 @@ Class AltiServicesFromDB {
                             ST_Transform(ST_SetSRID(ST_MakePoint(%5$f, %6$f),4326), %4$s)
                         )
                     AS geom
-                ),
+                ), 
                 linemesure AS(
                     -- Add a mesure dimension to extract steps
                     SELECT
@@ -126,19 +126,19 @@ Class AltiServicesFromDB {
                             ELSE %8$d*5
                         END as resolution
                     FROM line
-                ),
+                ), 
                 points2d AS (
-                    SELECT ST_GeometryN(ST_LocateAlong(linem, i), 1) AS geom, resolution FROM linemesure
+                    SELECT ST_GeometryN(ST_LocateAlong(linem, i), 1) AS geom, resolution FROM linemesure ORDER BY i
                 ),
                 cells AS (
                     -- Get DEM elevation for each
-                    SELECT
-                        p.geom AS geom,
-                        ST_Value(%1$s.rast, 1, p.geom) AS val,
+                    SELECT 
+                        p.geom AS geom, 
+                        ST_Value(%1$s.rast, 1, p.geom) AS val,                      
                         resolution
                     FROM %1$s, points2d p
                     WHERE ST_Intersects(%1$s.rast, p.geom)
-                ),
+                ),           
                 -- Instantiate 3D points
                 points3d AS (
                     SELECT ST_SetSRID(
@@ -150,15 +150,15 @@ Class AltiServicesFromDB {
                     SELECT ST_MakeLine(geom)as geom, MAX(resolution) as resolution FROM points3d
                 ),
                 xz AS(
-                    SELECT dp.geom as geom, dp.path[1] as pt_index, ST_distance(origin, dp.geom) as dist, resolution
-                    FROM (
-                       SELECT ST_DumpPoints(geom) AS dp,
-                       ST_StartPoint(geom) AS origin, resolution
-                       FROM line3D
-                    ) as dumpline3D
+																													
+						  
+                    SELECT (ST_DumpPoints(geom)).geom AS geom,
+                    ST_StartPoint(geom) AS origin, resolution
+                    FROM line3D
+								   
                 )
             -- Build 3D line from 3D points
-            SELECT dist AS x, ST_Z(geom) as y, ST_X(geom) as lon, ST_Y(geom) as lat, resolution FROM xz ORDER BY pt_index',
+            SELECT ST_distance(origin, geom) AS x, ST_Z(geom) as y, ST_X(geom) as lon, ST_Y(geom) as lat, resolution FROM xz',
             $this->AltiProfileTable,
             $p1Lon, $p1Lat,
             $this->Srid,
@@ -230,3 +230,4 @@ Class AltiServicesFromDB {
         return json_encode($data);
     }
 }
+


### PR DESCRIPTION
Fixed problem with the point ordering resulting in "circular" profiles ( https://github.com/arno974/lizmap-altiProfil/issues/30# )