### PR TITLE
use () to access properties from composite type returned by ST_DumpPoints

### DIFF
--- a/altiProfil/lib/AltiServicesFromDB.php
+++ b/altiProfil/lib/AltiServicesFromDB.php
@@ -150,7 +150,7 @@ Class AltiServicesFromDB {
                     SELECT ST_MakeLine(geom)as geom, MAX(resolution) as resolution FROM points3d
                 ),
                 xz AS(
-                    SELECT dp.geom as geom, dp.path[1] as pt_index, ST_distance(origin, dp.geom) as dist, resolution
+                    SELECT (dp).geom as geom, (dp).path[1] as pt_index, ST_distance(origin, (dp).geom) as dist, resolution
                     FROM (
                        SELECT ST_DumpPoints(geom) AS dp,
                        ST_StartPoint(geom) AS origin, resolution


### PR DESCRIPTION
untested on fresh install but SQL is Ok

avoid error
```log

 Erreur dans la requête (ERREUR:  entrée manquante de la clause FROM pour la table « dp »
LINE 54:                     SELECT dp.geom as geom, dp.path[1] as pt...
                                    ^(
            WITH
                line AS(
                    -- From an arbitrary line
                    SELECT
                        ST_MakeLine(
                            ST_Transform(ST_SetSRID(ST_MakePoint(55.414920, -21.030142),4326), 2975),
                            ST_Transform(ST_SetSRID(ST_MakePoint(55.486331, -21.058339),4326), 2975)
                        )
                    AS geom
                ),
                linemesure AS(
                    -- Add a mesure dimension to extract steps
                    SELECT
                        ST_AddMeasure(line.geom, 0, ST_Length(line.geom)) as linem,
                        generate_series(
                            0,
                            ST_Length(line.geom)::int,
                            --for very long line we reduce the steps
                            CASE
                                WHEN ST_Length(line.geom)::int < 1000 THEN 5
                                ELSE 5*5
                            END
                        ) as i,
                        CASE
                            WHEN ST_Length(line.geom)::int < 1000 THEN 5
                            ELSE 5*5
                        END as resolution
                    FROM line
                ),
                points2d AS (
                    SELECT ST_GeometryN(ST_LocateAlong(linem, i), 1) AS geom, resolution FROM linemesure
                ),
                cells AS (
                    -- Get DEM elevation for each
                    SELECT
                        p.geom AS geom,
                        ST_Value(gonogo_references.mnt5m.rast, 1, p.geom) AS val,
                        resolution
                    FROM gonogo_references.mnt5m, points2d p
                    WHERE ST_Intersects(gonogo_references.mnt5m.rast, p.geom)
                ),
                -- Instantiate 3D points
                points3d AS (
                    SELECT ST_SetSRID(
                                ST_MakePoint(ST_X(geom), ST_Y(geom), val),
                                2975
                            ) AS geom, resolution FROM cells
                ),
                line3D AS(
                    SELECT ST_MakeLine(geom)as geom, MAX(resolution) as resolution FROM points3d
                ),
                xz AS(
                    SELECT dp.geom as geom, dp.path[1] as pt_index, ST_distance(origin, dp.geom) as dist, resolution
                    FROM (
                       SELECT ST_DumpPoints(geom) AS dp,
                       ST_StartPoint(geom) AS origin, resolution
                       FROM line3D
                    ) as dumpline3D
                )
            -- Build 3D line from 3D points
            SELECT dist AS x, ST_Z(geom) as y, ST_X(geom) as lon, ST_Y(geom) as lat, resolution FROM xz ORDER BY pt_index))
```` 

[postgis ST_DumpPoints doc](https://postgis.net/docs/manual-3.4/en/ST_DumpPoints.html)

[postgreSQL composite type](https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-ACCESSING)