### PR TITLE
Desactivate Popup Control when using Altiprofil

### DIFF
--- a/altiProfil/install/config/altiProfil.ini.php.dist
+++ b/altiProfil/install/config/altiProfil.ini.php.dist
@@ -13,4 +13,4 @@ dock=dock
 ;si cas IGN
 altiProfileProvider=ign
 ignServiceKey=essentiels
-ignServiceUrl=https://wxs.ign.fr/
+ignServiceUrl="https://data.geopf.fr/altimetrie/1.0/calcul"

--- a/altiProfil/install/www/altiprofil/js/altiProfil.js
+++ b/altiProfil/install/www/altiprofil/js/altiProfil.js
@@ -233,7 +233,9 @@ function initAltiProfil() {
         altiProfilLayer.setVisibility(true);
     }
 
+    // add altiprofilCtrl prop to Control with value true to distiguish it
     OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control, {
+        'altiprofilCtrl' :true,
         defaultHandlerOptions: {
             'single': true,
             'double': false,
@@ -292,6 +294,10 @@ function initAltiProfil() {
             if (ctrl.CLASS_NAME == 'OpenLayers.Control.WMSGetFeatureInfo'){
                 ctrl.deactivate();
             }
+            // desactivate existing control which handle single click (TODO : should store previous state if multiple controls of this kind)
+            if (ctrl.CLASS_NAME == 'OpenLayers.Control' && ctrl.defaultHandlerOptions?.single == true && ctrl?.altiprofilCtrl != true) {
+                ctrl.deactivate();
+            }
         });
         altiProfilLayer.setVisibility(true);
         profilClick.activate();
@@ -301,6 +307,10 @@ function initAltiProfil() {
         var controls = lizMap.map.controls;
         controls.forEach(function (ctrl) {
             if (ctrl.CLASS_NAME == 'OpenLayers.Control.WMSGetFeatureInfo'){
+                ctrl.activate();
+            }
+            // activate existing control which handle single click
+            if (ctrl.CLASS_NAME == 'OpenLayers.Control' && ctrl.defaultHandlerOptions?.single == true && ctrl?.altiprofilCtrl != true) {
                 ctrl.activate();
             }
         });


### PR DESCRIPTION
In LWC 3.7 the PopupControl is catching all click event, altiprofil is unable to work without disabling queryable layers.

during initialisation, i add a property to all control with same behaviour, and when enabling/disabling altiProfil the matching control are desactivated/activated 
