### PR TITLE
Add Layer to Top using addToolLayer, check visibility before performing click

### DIFF
--- a/altiProfil/install/www/altiprofil/js/altiProfil.js
+++ b/altiProfil/install/www/altiprofil/js/altiProfil.js
@@ -241,7 +241,8 @@ function initAltiProfil() {
         style: styles,
         source: altiProfilSource,
         projection : lizMap.map.projection,
-        properties : {"altiprofil" : true}
+        properties : {"altiprofil" : true},
+        visible : false
     });
 
     function onAltiDockOpened() {
@@ -297,7 +298,7 @@ function initAltiProfil() {
     lizMap.mainLizmap.map.addToolLayer(altiProfilLayer);
 
     lizMap.mainLizmap.map.on('singleclick', evt => {
-            if (! lizMap.mainLizmap.popup.active ) {
+            if (altiProfilLayer.getVisible()) {
                 let nbFeatures = altiProfilSource.getFeatures().length;
                 if(nbFeatures>=2){
                     altiProfilSource.clear();

--- a/altiProfil/install/www/altiprofil/js/altiProfil.js
+++ b/altiProfil/install/www/altiprofil/js/altiProfil.js
@@ -222,7 +222,6 @@ function getProfil(p1,p2){
 }
 
 function initAltiProfil() {
-    var map = lizMap.map;
     //Layer to display clic location
     // define styes
     let styles = new lizMap.ol.style.Style({
@@ -295,7 +294,7 @@ function initAltiProfil() {
         }
     });
 
-    lizMap.mainLizmap.map.addLayer(altiProfilLayer);
+    lizMap.mainLizmap.map.addToolLayer(altiProfilLayer);
 
     lizMap.mainLizmap.map.on('singleclick', evt => {
             if (! lizMap.mainLizmap.popup.active ) {
@@ -305,6 +304,7 @@ function initAltiProfil() {
                     $('#altiProfil .menu-content #profil-chart').hide();
                     $('#altiProfil .menu-content #profil-chart-container').empty();
                     $('#altiProfil .menu-content span').html( "..." );
+                    nbFeatures = 0;
                 }
 
                 const feature = new lizMap.ol.Feature({


### PR DESCRIPTION
Fix #41 

To ensure Vector layer are still on top we must use `addToolLayer` method

Additionnaly : 

singleclick event can be fired when popup is inactive and altiprofil not enabled ( for exemple external script which disable popup using `lizMap.mainLizmap.popup.active = false;`

let's ensure altiprofilLayer is visible (ie dock is enabled, and disabling popup) before performing the action.
