### PR TITLE
Remove legacy strings about IGN key

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,7 @@ altiresolution=DEM resolution
 
 ;if IGN French data provider
 ;altiProfileProvider= ign
-ignServiceKey=votre clé IGN / your IGN key
 ignServiceUrl=https://wxs.ign.fr/
-
 ```
 
 You can specify your data source.

--- a/altiProfil/install/config/altiProfil.ini.php.dist
+++ b/altiProfil/install/config/altiProfil.ini.php.dist
@@ -12,5 +12,4 @@ dock=dock
 
 ;si cas IGN
 altiProfileProvider=ign
-ignServiceKey=essentiels
 ignServiceUrl="https://data.geopf.fr/altimetrie/1.0/calcul"

--- a/altiProfil/lib/AltiConfig.php
+++ b/altiProfil/lib/AltiConfig.php
@@ -18,7 +18,6 @@ class AltiConfig
             'altisource' => '',
             'altiProfileTable' => '',
             'altiProfileProvider'=>'ign',
-            'ignServiceKey' => 'essentiels',
             'ignServiceUrl' => 'https://data.geopf.fr/altimetrie/1.0/calcul',
             'dock'=>'dock',
             'srid'=>'3857',

--- a/altiProfilAdmin/locales/en_US/admin.UTF-8.properties
+++ b/altiProfilAdmin/locales/en_US/admin.UTF-8.properties
@@ -16,7 +16,6 @@ form.dock.minidock.label=Mini-dock
 form.dock.rightdock.label=Right-dock
 form.altiProfileTable.label=Database table
 form.srid.label=SRID
-form.ignServiceKey.label=IGN key
 form.ignServiceUrl.label=IGN service URL
 form.altiresolution.label=Resolution
 form.connection_check.label=Connection status

--- a/altiProfilAdmin/locales/fr_FR/admin.UTF-8.properties
+++ b/altiProfilAdmin/locales/fr_FR/admin.UTF-8.properties
@@ -16,7 +16,6 @@ form.dock.minidock.label=Mini-dock
 form.dock.rightdock.label=Right-dock
 form.altiProfileTable.label=Table de la base
 form.srid.label=SRID
-form.ignServiceKey.label=Clé IGN
 form.ignServiceUrl.label=URL du service IGN
 form.altiresolution.label=Résolution
 form.connection_check.label=Status de la connection

--- a/altiProfilAdmin/locales/ro_RO/admin.UTF-8.properties
+++ b/altiProfilAdmin/locales/ro_RO/admin.UTF-8.properties
@@ -14,5 +14,4 @@ form.dock.minidock.label=Mini-doc
 form.dock.rightdock.label=Dock-dreapta
 form.altiProfileTable.label=Tabelul bazei de date
 form.srid.label=SRID
-form.ignServiceKey.label=Cheie IGN
 form.ignServiceUrl.label=URL serviciu IGN


### PR DESCRIPTION
The French IGN works without a key : https://geoservices.ign.fr/documentation/services/services-geoplateforme/altimetrie

https://data.geopf.fr/altimetrie/1.0/calcul/alti/rest/elevation.json?lon=1.48|1.49&lat=43.54|43.55&resource=ign_rge_alti_wld&delimiter=|&indent=true&measures=false&zonly=true

