### PR TITLE
Allow define raster table schema name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ with some extra keywords : backend, tests, test, translation, funders, important
 
 ### Changed
 
+* Allow define raster table schema name
+
 ## 0.5.5 - 2024-10-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Go to the configuration part.
 * Modules need to be enabled in Lizmap by editing the configuration file `lizmap/var/config`.
 
 
-For Lizmap 3.4 or Lizmap 3.5, add in the file `lizmap/var/config/localconfig.ini.php`, in the `[module]` section, 
+For Lizmap 3.4 or Lizmap 3.5, add in the file `lizmap/var/config/localconfig.ini.php`, in the `[module]` section,
 the reference to these 2 modules. Do not remove references to other modules in this section.
 
 ```ini
@@ -83,7 +83,7 @@ lizmap/install/set_rights.sh
 
 ## Configuration
 
-It's necessary to go in the administration panel of Lizmap Web Client to set up the module. 
+It's necessary to go in the administration panel of Lizmap Web Client to set up the module.
 
 ![Administration panel](altiProfilAdmin.png)
 
@@ -95,6 +95,7 @@ altisource=Source of data
 
 ;if database
 altiProfileProvider=database
+altiProfileSchema=dem_schema
 altiProfileTable=dem_table
 srid=3957
 ; profilUnit = PERCENT or DEGREES - unit for the profil
@@ -126,7 +127,7 @@ altiProfileProvider=ign
 ## Override the configuration for a single project
 
 For every project published in Lizmap, for instance `my_project.qgs`, you can add a new file with extension `.alti` at the end of the file.
-In our example, it would be `my_project.qgs.alti`. 
+In our example, it would be `my_project.qgs.alti`.
 
 This file allows you to override some settings.
 
@@ -135,6 +136,7 @@ For instance
 ```ini
 [altiProfil]
 altisource="DEM Paris high-resolution"
+altiProfileSchema=srtm
 altiProfileTable=srtm_paris_high_resolution
 srid=3857
 ```

--- a/altiProfil/install/config/altiProfil.ini.php.dist
+++ b/altiProfil/install/config/altiProfil.ini.php.dist
@@ -3,6 +3,7 @@ altisource=Source des données
 
 ;si cas database
 ;altiProfileProvider=database
+altiProfileSchema=dem_schema
 altiProfileTable=dem_table
 srid=3957
 ; profilUnit = PERCENT or DEGREES - choix de l'unité de calcul du profil

--- a/altiProfil/lib/AltiConfig.php
+++ b/altiProfil/lib/AltiConfig.php
@@ -16,6 +16,7 @@ class AltiConfig
         }
         $defaultValues =  array(
             'altisource' => '',
+            'altiProfileSchema' => '',
             'altiProfileTable' => '',
             'altiProfileProvider'=>'ign',
             'ignServiceUrl' => 'https://data.geopf.fr/altimetrie/1.0/calcul',
@@ -26,9 +27,42 @@ class AltiConfig
 
         );
         $values = parse_ini_file($altiProfilConfigFile, true, INI_SCANNER_TYPED);
-        $this->parameters = array_merge($defaultValues, $values['altiProfil']);
+        if ($values && array_key_exists('altiProfil', $values)) {
+            $this->parameters = array_merge($defaultValues, $values['altiProfil']);
+        } else {
+            $this->parameters = $defaultValues;
+        }
     }
 
+    public function setProjectConfig($repository, $project)
+    {
+        $p = \lizmap::getProject($repository.'~'.$project);
+        if (!$p) {
+            return false;
+        }
+
+        $alti_config_file = $p->getQgisPath() . '.alti';
+        if (!file_exists($alti_config_file)) {
+            return false;
+        }
+
+        $values = parse_ini_file($alti_config_file, true, INI_SCANNER_TYPED);
+        if (!$values || !array_key_exists('altiProfil', $config)) {
+            return false;
+        }
+
+        $this->parameters = array_merge($this->parameters, $values['altiProfil']);
+        return true;
+    }
+
+    public function getValue($key)
+    {
+        if (array_key_exists($key, $this->parameters)) {
+            return $this->parameters[$key];
+        }
+
+        return null;
+    }
 
     public function getProvider()
     {
@@ -55,14 +89,50 @@ class AltiConfig
         return $this->parameters['srid'];
     }
 
+    public function getAltiResolution()
+    {
+        return $this->parameters['altiresolution'];
+    }
+
+    public function getAltiProfileSchema()
+    {
+        return $this->parameters['altiProfileSchema'];
+    }
+
     public function getAltiProfileTable()
     {
         return $this->parameters['altiProfileTable'];
     }
 
-    public function getAltiResolution()
+    public function quotedSchemaTableName()
     {
-        return $this->parameters['altiresolution'];
+        if ($this->parameters['altiProfileSchema'] != '') {
+            return sprintf(
+                '"%1$s"."%2$s"',
+                $this->parameters['altiProfileSchema'],
+                $this->parameters['altiProfileTable']
+            );
+        } else {
+            return sprintf(
+                '"%1$s"',
+                $this->parameters['altiProfileTable']
+            );
+        }
+    }
+
+    /**
+     * Check connection
+     */
+    public function checkConnection() {
+        try{
+          $sql = sprintf('SELECT rast FROM %1$s limit 0', $this->quotedSchemaTableName());
+          $cnx = \jDb::getConnection( 'altiProfil' );
+          $qResult = $cnx->query( $sql);
+          return true;
+        } catch (\Exception $e) {
+             jLog::log("AltiProfil Admin :: ".$e->getMessage());
+        }
+        return false;
     }
 
     /**

--- a/altiProfilAdmin/forms/config.form.xml
+++ b/altiProfilAdmin/forms/config.form.xml
@@ -35,6 +35,10 @@
 <group ref="database">
   <label locale="altiProfilAdmin~admin.form.group.database.label"/>
 
+  <input ref="altiProfileSchema" type="string" defaultvalue="dem_schema" pattern='/^[a-zA-Z0-9_]+$/'>
+   <label locale="altiProfilAdmin~admin.form.altiProfileSchema.label" />
+  </input>
+
   <input ref="altiProfileTable" type="string" defaultvalue="dem_table" pattern='/^[a-zA-Z0-9_]+$/'>
    <label locale="altiProfilAdmin~admin.form.altiProfileTable.label" />
   </input>

--- a/altiProfilAdmin/locales/en_US/admin.UTF-8.properties
+++ b/altiProfilAdmin/locales/en_US/admin.UTF-8.properties
@@ -14,6 +14,7 @@ form.dock.label=Dock panel
 form.dock.dock.label=Dock
 form.dock.minidock.label=Mini-dock
 form.dock.rightdock.label=Right-dock
+form.altiProfileSchema.label=Database schema
 form.altiProfileTable.label=Database table
 form.srid.label=SRID
 form.ignServiceUrl.label=IGN service URL

--- a/altiProfilAdmin/locales/fr_FR/admin.UTF-8.properties
+++ b/altiProfilAdmin/locales/fr_FR/admin.UTF-8.properties
@@ -14,6 +14,7 @@ form.dock.label=Panneau
 form.dock.dock.label=Dock
 form.dock.minidock.label=Mini-dock
 form.dock.rightdock.label=Right-dock
+form.altiProfileSchema.label=Schéma de la base
 form.altiProfileTable.label=Table de la base
 form.srid.label=SRID
 form.ignServiceUrl.label=URL du service IGN

--- a/altiProfilAdmin/locales/ro_RO/admin.UTF-8.properties
+++ b/altiProfilAdmin/locales/ro_RO/admin.UTF-8.properties
@@ -12,6 +12,7 @@ form.dock.label=Panoul de andocare
 form.dock.dock.label=Doc
 form.dock.minidock.label=Mini-doc
 form.dock.rightdock.label=Dock-dreapta
+form.altiProfileSchema.label=Schema bazei de date
 form.altiProfileTable.label=Tabelul bazei de date
 form.srid.label=SRID
 form.ignServiceUrl.label=URL serviciu IGN

--- a/tests/lizmap/instances/altiprofil/altiprofil.qgs
+++ b/tests/lizmap/instances/altiprofil/altiprofil.qgs
@@ -1395,7 +1395,7 @@
 &lt;li&gt;Click on `Modify` button&lt;/li&gt;
 &lt;li&gt;Choose `PostgreSQL database table` for `Altitude provider`&lt;/li&gt;
 &lt;li&gt;Put `5` for `Resolution`&lt;/li&gt;
-&lt;li&gt;Enter `raster.rgealti_5m_mtp` for `Database table`&lt;/li&gt;
+&lt;li&gt;Enter `raster` for `Database schema` and `rgealti_5m_mtp` for `Database table`&lt;/li&gt;
 &lt;li&gt;Put `2154` for `SRID`&lt;/li&gt;
 &lt;li&gt;Save, get back to map and do the same steps as with the IGN API&lt;/li&gt;
 &lt;/ol&gt;


### PR DESCRIPTION
Since allowing uppercase in raster table name, it is necessary to allow define raster table schema name to do not modify the profile.

Fixed #57 