### PR TITLE
Update  data plotly asset path for LWC 3.8.4 + IGN data as objet

### DIFF
--- a/altiProfil/classes/altiProfil.listener.php
+++ b/altiProfil/classes/altiProfil.listener.php
@@ -88,14 +88,20 @@ class altiProfilListener extends jEventListener{
             // Add Dataviz if not already available
             if ( !$this->getDatavizStatus($event) ) {
 
+                // old LWC version ?
                 if (file_exists(jApp::wwwPath('js/dataviz/plotly-latest.min.js'))) {
                     $js[] = $bp.'js/dataviz/plotly-latest.min.js';
                     $js[] = $bp.'js/dataviz/dataviz.js';
-                }
-                if (file_exists(jApp::wwwPath('assets/js/dataviz/plotly-latest.min.js'))) {
+                } elseif (file_exists(jApp::wwwPath('assets/js/dataviz/plotly-latest.min.js'))) {
+                    // LWC 3.6, 3.7, <3.84
                     $js[] = $bp.'assets/js/dataviz/plotly-latest.min.js';
                     $js[] = $bp.'assets/js/dataviz/dataviz.js';
+                } elseif (file_exists(jApp::wwwPath('assets/js/dataviz/plotly-custom.min.js'))) {
+                    // since LWC 3.8.4 plotly asset is 'plotly-custom'
+                    $js[] = $bp.'assets/js/dataviz/plotly-custom.min.js';
+                    $js[] = $bp.'assets/js/dataviz/dataviz.js';
                 }
+                // add lang
                 if (file_exists(jApp::wwwPath('assets/js/dataviz/plotly-locale-'.$locale.'-latest.js'))) {
                     $js[] = $bp.'assets/js/dataviz/plotly-locale-'.$locale.'-latest.js';
                 }

--- a/altiProfil/classes/altiProfil.listener.php
+++ b/altiProfil/classes/altiProfil.listener.php
@@ -93,7 +93,7 @@ class altiProfilListener extends jEventListener{
                     $js[] = $bp.'js/dataviz/plotly-latest.min.js';
                     $js[] = $bp.'js/dataviz/dataviz.js';
                 } elseif (file_exists(jApp::wwwPath('assets/js/dataviz/plotly-latest.min.js'))) {
-                    // LWC 3.6, 3.7, <3.84
+                    // LWC 3.6, 3.7, <3.8.4
                     $js[] = $bp.'assets/js/dataviz/plotly-latest.min.js';
                     $js[] = $bp.'assets/js/dataviz/dataviz.js';
                 } elseif (file_exists(jApp::wwwPath('assets/js/dataviz/plotly-custom.min.js'))) {

--- a/altiProfil/lib/AltiServicesFromIGN.php
+++ b/altiProfil/lib/AltiServicesFromIGN.php
@@ -40,18 +40,18 @@ Class AltiServicesFromIGN
 
         $urlAltiIGN = $this->config->getIgnServiceUrl($APIRestElev, $data);
 
-        list($data, $mime, $code) = \lizmapProxy::getRemoteData($urlAltiIGN);
+        list($data, $mime, $code) = \Lizmap\Request\Proxy::getRemoteData($urlAltiIGN);
         $code = 200;
         if ($code == 200) {
             //DATA SHOULD BE LIKE '{"elevations":[{"x":55.38025625,"y":-21.14050849,"z":2154.75,"acc":2.5}]}'
             /* FOR TESTING
             $data = '{"elevations":[{"x":55.38025625,"y":-21.14050849,"z":2154.75,"acc":2.5}]}' ;
             */
-            return $data;
+            return json_decode($data);
         }else{
             $errorMsg = "AltiProfil IGN wrong request";
             \jLog::log($errorMsg);
-            return '{"error msg": "'.$data.'" }';
+            return array("error msg" => $data);
         }
     }
 
@@ -72,7 +72,7 @@ Class AltiServicesFromIGN
 
         $fullURL = $this->config->getIgnServiceUrl($APIRestProfil, $data);
 
-        list($data, $mime, $code) = \lizmapProxy::getRemoteData($fullURL);
+        list($data, $mime, $code) = \Lizmap\Request\Proxy::getRemoteData($fullURL);
 
         /* FOR TESTING
         $data = '{


### PR DESCRIPTION
Since LWC 3.8.4

`data-plotly` js file is named `plotly-custom.min.js`  (https://github.com/3liz/lizmap-web-client/commit/131107448e03e55a88f32a2d2f05facbf260e28f)

Use proper Proxy Class

For IGN provider : add json_encode to data , since request content is no more "JSON parsed" on js side
